### PR TITLE
Update repo URL for Heroku's CNB builder images

### DIFF
--- a/coolify-v3/applications/heroku.md
+++ b/coolify-v3/applications/heroku.md
@@ -41,6 +41,6 @@ head:
       content: https://cdn.coollabs.io/assets/coollabs/og-image-applications.png
 ---
 # Heroku
-Based on [heroku builder](https://github.com/heroku/builder).
+Based on [heroku builder](https://github.com/heroku/cnb-builder-images).
 
 You can easily migrate your Heroku applications with this build pack.


### PR DESCRIPTION
Since the repo has just been renamed:
https://github.com/heroku/cnb-builder-images/issues/396